### PR TITLE
Corrección de los diccionatios (conceptual y relacional)

### DIFF
--- a/4/4.2/4.2.md
+++ b/4/4.2/4.2.md
@@ -7,7 +7,7 @@ Semántica: Documento que solicita el inicio de un proceso de producción.
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad** |**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
 |COD\_SOLICITUD\_PRODUCCION|Identificador|Texto|Único, no nulo|—|—|Identificador único e irrepetible de la solicitud de producción|Permite el control y seguimiento de las solicitudes de producción hechas por el área del almacén|
-|CODIGO\_PRODUCTO|Identificador|Texto|Único, no nulo|—|—|Identificador del producto que se producirá mediante la orden|Relaciona la solicitud con un producto específico para planificar y controlar su fabricación|
+|COD\_PRODUCTO|Identificador|Texto|Único, no nulo|—|—|Identificador del producto que se producirá mediante la orden|Relaciona la solicitud con un producto específico para planificar y controlar su fabricación|
 |CANTIDAD\_REQUERIDA|Descriptivo|Numérico|Valores enteros mayores a cero|Kilogramos|—|Número total de unidades que se solicitan en uno o más lotes para abastecer el almacén|Define el volumen de producto necesario para cubrir una demanda específica.|
 |FECHA\_REQUERIDA|Temporal|Fecha|Válido de calendario|—|—|Fecha prevista para el cumplimiento de la solicitud|Ayuda a garantizar que la producción se ajuste a los plazos requeridos, evitando retrasos|
 |FECHA\_SOLICITUD|Temporal|Fecha|Válido de Calendario|—|—|Fecha en que se registró la solicitud|Determina el momento de inicio del proceso de atención|
@@ -77,13 +77,13 @@ Semántica: Etapa donde se realiza la medición de los insumos de acuerdo con la
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad** |**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :- | :- | :- | :- | :- | :- | :- | :- |
-|CODIGO\_DOSIFICADO|Identificador|Texto|Único, no nulo|—|—|Identificador único del proceso de dosificado|Registra la medición de los insumos correspondientes a un lote de producto|
-|CODIGO\_LOTE\_PRODUCTO|Identificador|Texto|<p>Existente en LoteProducto</p><p></p>|—|—|Identificador único del lote del producto al que corresponde la dosificación|Permite relacionar el proceso de dosificación con un lote específico de producto|
+|COD\_DOSIFICADO|Identificador|Texto|Único, no nulo|—|—|Identificador único del proceso de dosificado|Registra la medición de los insumos correspondientes a un lote de producto|
+|COD\_LOTE\_PRODUCTO|Identificador|Texto|<p>Existente en LoteProducto</p><p></p>|—|—|Identificador único del lote del producto al que corresponde la dosificación|Permite relacionar el proceso de dosificación con un lote específico de producto|
 |FECHA\_PROCESO|Temporal|Fecha|Válido de calendario|—|—|Fecha en que se realizó el proceso de dosificación|Indica el inicio de la elaboración del lote de producto|
 |HORA\_INICIO|Temporal|Hora|Válida según zona horaria|—|—|Hora exacta en la que se realizó la dosificación|Indica con exactitud el momento donde inició el dosificado con fines de trazabilidad|
 |TIEMPO\_PROCESO|Númerico|Decimal |Valores mayores a cero|minutos|—|Duración total del proceso de dosificado por ejemplar de máquina|Permite monitorear los tiempos de dosificado por máquina y evaluar la eficiencia del proceso|
-|CODIGO\_EMPLEADO|Identificador|Texto|Existente en Empleado|—|—|Identificador del empleado responsable de la dosificación|Sirve para identificar al operario responsable del ingreso de datos del dosificado|
-|NUMERO\_BATCH|Identificador|Numérico|Valores enteros mayores a cero|—|—|Identificador del ciclo de producción dentro de un lote. |Permite rastrear los ciclos internos del proceso de producción dentro de un lote. Facilita la trazabilidad y control de calidad.|
+|COD\_EMPLEADO|Identificador|Texto|Existente en Empleado|—|—|Identificador del empleado responsable de la dosificación|Sirve para identificar al operario responsable del ingreso de datos del dosificado|
+|NUM\_BATCH|Identificador|Numérico|Valores enteros mayores a cero|—|—|Identificador del ciclo de producción dentro de un lote. |Permite rastrear los ciclos internos del proceso de producción dentro de un lote. Facilita la trazabilidad y control de calidad.|
 |ESTADO|Estado|Texto|Completado, En proceso, En inspección, Retirado|—|—|Estado del proceso de dosificado|Facilita el seguimiento de cada proceso de dosificado para Control de Calidad y Control de Producción|
 
 
@@ -93,13 +93,13 @@ Semántica: Etapa donde se combinan los insumos para obtener la mezcla de la pas
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad** |**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :- | :- | :- | :- | :- | :- | :- | :- |
-|CODIGO\_MEZCLADO|Identificador|Texto|Único, no nulo|—|—|Identificador único del proceso de mezclado|Registra el detalle de los insumos usados en la mezcla correspondientes a un lote de producto|
-|CODIGO\_LOTE\_PRODUCTO|Identificador|Texto|<p>Existente en LoteProducto</p><p></p>|—|—|Identificador del lote de producto resultante del proceso de mezclado|Relaciona el proceso de mezclado con un lote específico, asegurando la trazabilidad|
+|COD\_MEZCLADO|Identificador|Texto|Único, no nulo|—|—|Identificador único del proceso de mezclado|Registra el detalle de los insumos usados en la mezcla correspondientes a un lote de producto|
+|COD\_LOTE\_PRODUCTO|Identificador|Texto|<p>Existente en LoteProducto</p><p></p>|—|—|Identificador del lote de producto resultante del proceso de mezclado|Relaciona el proceso de mezclado con un lote específico, asegurando la trazabilidad|
 |FECHA\_PROCESO|Temporal|Fecha|Válido de calendario|—|—|Fecha en la que se realizó el proceso de mezclado|Aporta información requerida para el proceso de auditoría|
-|CODIGO\_EMPLEADO|Identificador|Texto|Existente en Empleado|—|—|Identificador del empleado responsable del mezclado|Sirve para identificar al operario responsable del ingreso de datos del mezclado|
-|NUMERO\_BATCH|Identificador|Numérico|Valores enteros mayores a cero|—|—|Identificador del ciclo de producción dentro de un lote. |Permite rastrear los ciclos internos del proceso de producción dentro de un lote. Facilita la trazabilidad y control de calidad.|
-|CODIGO\_FORMULACIÓN|Identificador|Texto|Existente en Formulación|||Identificador de la formulación correspondiente a un producto|Asocia los insumos necesarios para producir el producto por lote |
-|CODIGO\_EJEMPLAR\_MAQUINA|Identificador|Texto|Existente en EjemplarMaquina|—|—|Identificador único de cada ejemplar de un tipo de máquina|Proporciona información detallada de cada ejemplar de máquina utilizada en el proceso de mezclado|
+|COD\_EMPLEADO|Identificador|Texto|Existente en Empleado|—|—|Identificador del empleado responsable del mezclado|Sirve para identificar al operario responsable del ingreso de datos del mezclado|
+|NUM\_BATCH|Identificador|Numérico|Valores enteros mayores a cero|—|—|Identificador del ciclo de producción dentro de un lote. |Permite rastrear los ciclos internos del proceso de producción dentro de un lote. Facilita la trazabilidad y control de calidad.|
+|COD\_FORMULACIÓN|Identificador|Texto|Existente en Formulación|||Identificador de la formulación correspondiente a un producto|Asocia los insumos necesarios para producir el producto por lote |
+|COD\_EJEMPLAR\_MAQUINA|Identificador|Texto|Existente en EjemplarMaquina|—|—|Identificador único de cada ejemplar de un tipo de máquina|Proporciona información detallada de cada ejemplar de máquina utilizada en el proceso de mezclado|
 |HORA\_INICIO|Temporal|Hora|Válida según zona horaria|—|—|Hora exacta en la que se inició el proceso de mezclado.|Indica con exactitud el momento donde inició el mezclado con fines de trazabilidad|
 |TIEMPO\_PROCESO|Númerico|Decimal |Valores mayores a cero|minutos|—|Duración total del proceso de mezclado por ejemplar de máquina|Permite monitorear los tiempos de mezclado por máquina y compararlo con el promedio en Control de Calidad|
 |PESO\_INICIAL|Númerico|Decimal |Valores mayores a cero|kilogramos||Cantidad de producto intermedio al iniciar el proceso de mezclado|Documenta el dato ingresado por el operario para el análisis correspondiente de Control de Calidad|
@@ -114,13 +114,13 @@ Semántica: Etapa donde se da la forma y el tamaño requerido de la pasta.
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :- | :- | :- | :- | :- | :- | :- | :- |
-|CODIGO\_MOLDEADO|Identificador|Texto|Único, no nulo|—|—|Identificador único del proceso de moldeado|Registra el detalle de un proceso de moldeado correspondiente a un lote de producto |
-|CODIGO\_LOTE\_PRODUCTO|Identificador|Texto|Existente en LoteProducto|—|—|Identificador del lote de producto sometido al proceso de moldeado|Relaciona el proceso de moldeado con un lote específico, asegurando la trazabilidad|
+|COD\_MOLDEADO|Identificador|Texto|Único, no nulo|—|—|Identificador único del proceso de moldeado|Registra el detalle de un proceso de moldeado correspondiente a un lote de producto |
+|COD\_LOTE\_PRODUCTO|Identificador|Texto|Existente en LoteProducto|—|—|Identificador del lote de producto sometido al proceso de moldeado|Relaciona el proceso de moldeado con un lote específico, asegurando la trazabilidad|
 |FECHA\_MOLDEADO|Temporal|Fecha|Válido de calendario|—|—|Fecha en la que se realizó el proceso de moldeado|Aporta información requerida para el proceso de auditoría|
-|CODIGO\_EMPLEADO|Identificador|Texto|Existente en Empleado|—|—|Identificador único del empleado que realizó el proceso de moldeado|Sirve para identificar al operario responsable del ingreso de datos del moldeado|
-|NUMERO\_BATCH|Identificador|Numérico|Valores enteros mayores a cero|—|—|Identificador del ciclo de producción dentro de un lote. |Permite rastrear los ciclos internos del proceso de producción dentro de un lote. Facilita la trazabilidad y control de calidad.|
+|COD\_EMPLEADO|Identificador|Texto|Existente en Empleado|—|—|Identificador único del empleado que realizó el proceso de moldeado|Sirve para identificar al operario responsable del ingreso de datos del moldeado|
+|NUM\_BATCH|Identificador|Numérico|Valores enteros mayores a cero|—|—|Identificador del ciclo de producción dentro de un lote. |Permite rastrear los ciclos internos del proceso de producción dentro de un lote. Facilita la trazabilidad y control de calidad.|
 |TIPO\_BOQUILLA|Categórico|Texto|Canuto, Tornillo, Spaguetti, Tagliatelle, Codo|—|—|Tipo de boquilla utilizado en el proceso|Determina la forma de la masa según las especificaciones del lote de producto|
-|CODIGO\_EJEMPLAR\_MAQUINA|Identificador|Texto|Existente en EjemplarMaquina|—|—|Identificador único de cada ejemplar de un tipo de máquina|Proporciona información detallada de cada ejemplar de máquina utilizada en el proceso de moldeado|
+|COD\_EJEMPLAR\_MAQUINA|Identificador|Texto|Existente en EjemplarMaquina|—|—|Identificador único de cada ejemplar de un tipo de máquina|Proporciona información detallada de cada ejemplar de máquina utilizada en el proceso de moldeado|
 |HORA\_INICIO|Temporal|Hora|Válida según zona horaria|—|—|Hora exacta en la que se inició el proceso de moldeado|Indica con exactitud el momento donde inició el moldeado con fines de trazabilidad|
 |TIEMPO\_PROCESO|Númerico|Decimal |Valores mayores a cero|minutos|—|Duración total del proceso de mezclado por ejemplar de máquina|Permite monitorear los tiempos de mezclado por máquina y compararlo con el promedio en Control de Calidad|
 |PESO\_INICIAL|Númerico|Decimal |Valores mayores a cero|kilogramos||Cantidad de producto intermedio al iniciar el proceso de moldeado|Documenta el dato ingresado por el operario para el análisis correspondiente de Control de Calidad|
@@ -136,16 +136,16 @@ Semántica: Etapa donde se reduce el porcentaje de humedad de la pasta.
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad** |**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :- | :- | :- | :- | :- | :- | :- | :- |
-|CODIGO\_SECADO|Identificador|Texto|Único, no nulo|—|—|Identificador único del proceso de secado|Registrar el detalle de un proceso de secado correspondiente a un lote de producto |
-|CODIGO\_LOTE\_PRODUCTO|Identificador|Texto|<p>Existente en LoteProducto</p><p></p>|—|—|Identificador del lote de producto que pasa por el proceso de secado|Relaciona el proceso de secado con un lote específico, asegurando la trazabilidad|
+|COD\_SECADO|Identificador|Texto|Único, no nulo|—|—|Identificador único del proceso de secado|Registrar el detalle de un proceso de secado correspondiente a un lote de producto |
+|COD\_LOTE\_PRODUCTO|Identificador|Texto|<p>Existente en LoteProducto</p><p></p>|—|—|Identificador del lote de producto que pasa por el proceso de secado|Relaciona el proceso de secado con un lote específico, asegurando la trazabilidad|
 |FECHA\_PROCESO|Temporal|Fecha|Válido de calendario|—|—|Fecha en la que se realizó el proceso de secado|Aporta información requerida para el proceso de auditoría|
-|CODIGO\_EMPLEADO|Identificador|Texto|Existente en Empleado|—|—|Identificador único del empleado que realizó el proceso de secado|Sirve para identificar al operario responsable del ingreso de datos del secado|
-|NUMERO\_BATCH|Identificador|Numérico|Valores enteros mayores a cero|—|—|Identificador del ciclo de producción dentro de un lote. |Permite rastrear los ciclos internos del proceso de producción dentro de un lote. Facilita la trazabilidad y control de calidad.|
-|CODIGO\_EJEMPLAR\_MAQUINA|Identificador|Texto|Existente en EjemplarMaquina|—|—|Identificador de la máquina utilizada para el secado|Proporciona una información más detallada del ejemplar de máquina que se utiliza en cada proceso de secado|
+|COD\_EMPLEADO|Identificador|Texto|Existente en Empleado|—|—|Identificador único del empleado que realizó el proceso de secado|Sirve para identificar al operario responsable del ingreso de datos del secado|
+|NUM\_BATCH|Identificador|Numérico|Valores enteros mayores a cero|—|—|Identificador del ciclo de producción dentro de un lote. |Permite rastrear los ciclos internos del proceso de producción dentro de un lote. Facilita la trazabilidad y control de calidad.|
+|COD\_EJEMPLAR\_MAQUINA|Identificador|Texto|Existente en EjemplarMaquina|—|—|Identificador de la máquina utilizada para el secado|Proporciona una información más detallada del ejemplar de máquina que se utiliza en cada proceso de secado|
 |HORA\_INICIO|Temporal|Hora|Válida según zona horaria|—|—|Hora exacta en la que se inició el proceso de secado|Indica con exactitud el momento donde inició el secado con fines de trazabilidad|
 |PESO\_INICIAL|Númerico|Decimal |Valores mayores a cero|kilogramos||Cantidad de producto intermedio al iniciar el proceso de secado|Documenta el dato ingresado por el operario para el análisis correspondiente de Control de Calidad|
 |MERMA|Númerico|Decimal |Valores mayores a cero|kilogramos|—|Cantidad de masa perdida que ocurre durante el proceso de secado|Documenta las pérdidas para el análisis correspondiente de Control de Calidad|
-|NUMERO\_BANDEJAS|Númerico|Entero |Valores mayores a cero|—|—|Cantidad de bandejas que se cargan por máquina de secado|Útil para medir volumen de producción y para el análisis correspondiente de Control de Calidad|
+|NUM\_BANDEJAS|Númerico|Entero |Valores mayores a cero|—|—|Cantidad de bandejas que se cargan por máquina de secado|Útil para medir volumen de producción y para el análisis correspondiente de Control de Calidad|
 |TEMPERATURA\_INICIAL|Númerico|Decimal |Valores mayores a cero|Celsius|—|Temperatura inicial a la que se programa la máquina de secado|Documenta el dato ingresado por el operario para el análisis correspondiente de Control de Calidad|
 |TEMPERATURA\_FINAL|Númerico|Decimal |Valores mayores a cero|Celsius|—|Temperatura final que resulta de la máquina de secado|Documenta el dato ingresado por el operario para el análisis correspondiente de Control de Calidad|
 |PORCENTAJE\_HUMEDAD|Númerico|Decimal |Valores mayores a cero|—|—|Porcentaje de humedad que se programa en la máquina|Documenta el dato ingresado por el operario para el análisis correspondiente de Control de Calidad|
@@ -158,11 +158,11 @@ Semántica: Etapa que incluye el envasado del producto en su presentación indiv
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad** |**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :- | :- | :- | :- | :- | :- | :- | :- |
-|CODIGO\_ENVASADO|Identificador |Texto|Único, no nulo|—|—|Identificador único del proceso de envasado|Registrar el detalle de un proceso de envasado, asegurando la trazabilidad del producto|
-|CODIGO\_LOTE\_PRODUCTO|Identificador|Texto|<p>Existente en LoteProducto</p><p></p>|—|—|Identificador del lote de producto que fue envasado|Relaciona el proceso de envasado con un lote específico, asegurando la trazabilidad|
+|COD\_ENVASADO|Identificador |Texto|Único, no nulo|—|—|Identificador único del proceso de envasado|Registrar el detalle de un proceso de envasado, asegurando la trazabilidad del producto|
+|COD\_LOTE\_PRODUCTO|Identificador|Texto|<p>Existente en LoteProducto</p><p></p>|—|—|Identificador del lote de producto que fue envasado|Relaciona el proceso de envasado con un lote específico, asegurando la trazabilidad|
 |FECHA\_PROCESO|Temporal|Fecha|Válido de calendario|—|—|Fecha en la que se realizó el proceso de envasado|Indica el momento en el que el lote de producto está listo para ser enviado a su envasado|
-|CODIGO\_EMPLEADO|Identificador|Texto|Existente en Empleado|—|—|Identificador único del empleado que realizó el proceso de envasado|Sirve para identificar al operario responsable del ingreso de datos del envasado|
-|NUMERO\_BATCH|Identificador|Numérico |Valores enteros mayores a cero|—|—|Identificador del ciclo de producción dentro de un lote. |Permite rastrear los ciclos internos del proceso de producción dentro de un lote. Facilita la trazabilidad y control de calidad.|
+|COD\_EMPLEADO|Identificador|Texto|Existente en Empleado|—|—|Identificador único del empleado que realizó el proceso de envasado|Sirve para identificar al operario responsable del ingreso de datos del envasado|
+|NUM\_BATCH|Identificador|Numérico |Valores enteros mayores a cero|—|—|Identificador del ciclo de producción dentro de un lote. |Permite rastrear los ciclos internos del proceso de producción dentro de un lote. Facilita la trazabilidad y control de calidad.|
 |TIPO\_ENVASE|Categórico|Texto|Bolsa, Caja de cartón|—|—|Tipo de envase del producto|Sirve para determinar el insumo específico con el que se envasó el producto|
 |HORA\_INICIO|Temporal|Hora|Válida según zona horaria|—|—|Hora exacta en la que se inició el proceso de envasado|Indica con exactitud el momento donde inició el envasado con fines de trazabilidad|
 |TIEMPO\_PROCESO|Númerico|Decimal |Valores mayores a cero|minutos|—|Duración total del proceso de envasado |Permite monitorear los tiempos de envasado y compararlo con el promedio en Control de Calidad|
@@ -191,7 +191,7 @@ Semántica: Validación realizada por el área de calidad sobre cada proceso ind
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
 |NUM\_INSPECCION\_PROCESO|Identificador|Texto|Único, no nulo|—|—|Código que identifica de forma única la inspección de un batch de proceso.|Permite individualizar y rastrear cada inspección en una etapa del proceso productivo.|
-|NUMERO\_BATCH|Identificador|Texto|Existente en Dosificado, Moldeado, Mezclado,Secado, Envasado|—|—|Número que identifica el lote de proceso asignado a una máquina o turno específico.|Permite ubicar y auditar cada evento de producción técnica asociada a un lote.|
+|NUM\_BATCH|Identificador|Texto|Existente en Dosificado, Moldeado, Mezclado,Secado, Envasado|—|—|Número que identifica el lote de proceso asignado a una máquina o turno específico.|Permite ubicar y auditar cada evento de producción técnica asociada a un lote.|
 |NUM\_LOTE\_PRODUCTO	|Identificador|Texto|Existente en LoteProducto|—|—|Identificador del lote de producto sobre el cual se realizó el proceso.|Establece la trazabilidad del producto inspeccionado.|
 |COD\_EMPLEADO|Identificador|Texto|Existente en Empleado|—|—|Inspector responsable de registrar los datos de inspección.|Asigna la responsabilidad del control de calidad a un trabajador autorizado.|
 |ESTADO\_REVISION	|Estado|Texto|Pendiente, Revisado|—|—|Estado actual de la inspección del proceso (Pendiente o Revisado).|Refleja el avance y situación de la validación de calidad.|
@@ -209,9 +209,9 @@ Semántica: Revisión final del lote antes del despacho, enfocada en los empaque
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-|ID\_INSPECCION\_ENVASADO|Identificador|Texto|Único, no nulo|—|—|Código único para identificar una inspección de envasado específica.|Permite distinguir cada validación del empaque final previo a la distribución.|
-|NUMERO\_BATCH|Identificador|Texto|Existente en Dosificado, Moldeado, Mezclado,Secado, Envasado|—|—|Número del lote interno en la etapa de envasado.|Relaciona la evaluación con el subproceso que origina el producto empacado.|
-|NUM\_LOTE\_PRODUCTO	|Identificador|Texto|Existente en LoteProducto|—|—|Lote del producto en revisión antes del despacho.|Garantiza que el lote a despachar cumpla con las condiciones de empaque.|
+|COD\_INSPECCION\_ENVASADO|Identificador|Texto|Único, no nulo|—|—|Código único para identificar una inspección de envasado específica.|Permite distinguir cada validación del empaque final previo a la distribución.|
+|NUM\_BATCH|Identificador|Texto|Existente en Dosificado, Moldeado, Mezclado,Secado, Envasado|—|—|Número del lote interno en la etapa de envasado.|Relaciona la evaluación con el subproceso que origina el producto empacado.|
+|NUM\_LOTE\_PRODUCTO|Identificador|Texto|Existente en LoteProducto|—|—|Lote del producto en revisión antes del despacho.|Garantiza que el lote a despachar cumpla con las condiciones de empaque.|
 |COD\_EMPLEADO|Identificador|Texto|Existente en Empleado|—|—|Inspector encargado de evaluar el empaque.|Trazabilidad de quién realizó la inspección.|
 |CANTIDAD\_ENVASES\_DEFECTUOSOS|Numérico|Entero|Valores mayores a cero|—|—|Total de unidades empacadas que presentaron fallos o imperfecciones.|Permite medir la eficiencia de la etapa de envasado y determinar si procede el despacho.|
 |ESTADO\_REVISION	|Estado|Texto|Pendiente, Revisado|—|—|Estado del proceso de revisión.|Refleja si el empaque fue validado correctamente o necesita retrabajo.|
@@ -264,7 +264,7 @@ Semántica: Requerimiento registrado para atender una falla o realizar una revis
 |HORA\_SOLICITUD|Temporal|Hora|Válido según Zona Horaria|—|—|Hora en la que se registró la solicitud|Identifica con exactitud el momento donde se generó la solicitud con fines de trazabilidad|
 |FECHA\_REQUERIDA|Temporal|Fecha|Válido de calendario|—|—|Fecha prevista para el cumplimiento de la solicitud|Ayuda a garantizar que el mantenimiento se ajuste a los plazos requeridos, evitando retrasos|
 |TIPO\_MANTENIMIENTO|Descriptivo|Texto|Preventivo, Correctivo|—|—|Indica si el mantenimiento es correctivo o preventivo|Ayuda que tipo de mantenimiento se ha realizado a la máquina|
-|ID\_EJEMPLAR\_MAQUINA|Identificador|Texto|Único, no nulo|—|Máquina|Identificador de la máquina relacionada|Relaciona la solicitud con la máquina que requiere mantenimiento|
+|COD\_EJEMPLAR\_MAQUINA|Identificador|Texto|Único, no nulo|—|Máquina|Identificador de la máquina relacionada|Relaciona la solicitud con la máquina que requiere mantenimiento|
 |ESTADO\_SOLICITUD|Estado|Texto|Pedniente, Atendida, Con retraso|—|—|Estado actual de la solicitud|Permite monitorear el flujo de atención de la solicitud|
 
 ## **ENTIDAD**: Orden de Mantenimiento
@@ -288,20 +288,11 @@ Semántica: Entidad legal que ofrece bienes o servicios con fines comerciales o 
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-|ID\_EMPRESA|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica a cada empresa|Facilita la información de cada empresa|
+|COD\_EMPRESA|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica a cada empresa|Facilita la información de cada empresa|
 |NOMBRE\_COMERCIAL|Descriptivo|Texto|Texto libre|—|—|Nombre con el que el empresa se presenta públicamente|Identifica a la empresa de forma comercial y visible para operaciones|
 |RAZON\_SOCIAL|Descriptivo|Texto|Texto libre|—|—|Nombre legal registrado de la empresa|Valida legalmente a la empresa en documentos oficiales y contratos|
-|CODIGO\_RUC|Descriptivo|Texto|Según SUNAT|—|—|Número único de Registro Único de Contribuyente de la empresa|Permite identificar a la empresa ante entidades tributarias y fiscales|
+|COD\_RUC|Descriptivo|Texto|Según SUNAT|—|—|Número único de Registro Único de Contribuyente de la empresa|Permite identificar a la empresa ante entidades tributarias y fiscales|
 |DIRECCION|Descriptivo|Texto|Texto libre|—|—|Ubicación física de la empresa|Facilita el contacto físico y la logística de envíos y reclamos|
-
-##  **ENTIDAD:** Telefono
-
-Semántica: Número de teléfono o teléfonos pertenecientes a la empresa para su comunicación.
-
-|**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
-| :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-|ID\_EMPRESA|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica a cada empresa|Identidad que vincula el número con la empresa|
-|TELEFONO|Descriptivo|Texto|Según Código de País|—|—|Número de contacto de la empresa|Medio de comunicación institucional|
 
 ##  **ENTIDAD:** Proveedor
 
@@ -309,9 +300,9 @@ Semántica: Entidad que suministra insumos a la empresa.
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-|ID\_PROVEEDOR|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica a cada proveedor|Facilita la información de cada proveedor|
+|COD\_PROVEEDOR|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica a cada proveedor|Facilita la información de cada proveedor|
 |CATEGORÍA|Categórico|Texto|Materia prima, aditivo, material empaque|—|—|Tipo de productos o servicios que ofrece el proveedor|Clasifica al proveedor según los insumos que puede suministrar|
-|ID\_INSUMO|Relacional|Texto|Existente en Insumo, no nulo|—|Insumo|Identificador del insumo que vende el proveedor |Relaciona el proveedor con los insumos que ofrece|
+|COD\_INSUMO|Relacional|Texto|Existente en Insumo, no nulo|—|Insumo|Identificador del insumo que vende el proveedor |Relaciona el proveedor con los insumos que ofrece|
 
 ##  **ENTIDAD:** Solicitud de abastecimiento
 
@@ -319,12 +310,12 @@ Semántica: Pedido de insumos generado por el área de almacén para reponer sto
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-|ID\_SOLICITUD\_ABASTECIMIENTO|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica cada solicitud de abastecimiento|Facilita la información de cada solicitud de abastecimiento|
-|ID\_EMPLEADO|Relacional|Texto|Existente en Empleado, no nulo|—|Empleado|Identificador del empleado del área de almacén que solicita el abastecimiento|Permite rastrear al responsable de emitir la solicitud de insumos|
+|COD\_SOLICITUD\_ABASTECIMIENTO|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica cada solicitud de abastecimiento|Facilita la información de cada solicitud de abastecimiento|
+|COD\_EMPLEADO|Relacional|Texto|Existente en Empleado, no nulo|—|Empleado|Identificador del empleado del área de almacén que solicita el abastecimiento|Permite rastrear al responsable de emitir la solicitud de insumos|
 |FECHA\_SOLICITUD\_ABASTECIMIENTO|Temporal|Fecha|Válido en calendario|—|—|Día exacto en que se registra la solicitud de abastecimiento|Establece cuándo se genera la necesidad de reposición de insumos|
 |HORA\_SOLICITUD\_ABASTECIMIENTO|Temporal|Hora|Válida según zona horaria |—|—|Hora específica en que se realiza la solicitud|Detalla el momento exacto de la solicitud para seguimiento y trazabilidad|
 |ESTADO\_SOLICITUD\_ABASTECIMIENTO|Estado|Texto|Pendiente, atendido|—|—|Indica si la solicitud está pendiente, atendida o rechazada|Refleja el avance del proceso de atención de la solicitud|
-|ID\_DETALLE\_ABASTECIMIENTO|Relacional|Texto|Existente en Detalle de abastecimiento, no nulo|—|Detalle de abastecimiento|Referencia al detalle de insumos y cantidades solicitadas|Especifica los insumos requeridos, fundamentales para la planificación de la compra|
+|COD\_DETALLE\_ABASTECIMIENTO|Relacional|Texto|Existente en Detalle de abastecimiento, no nulo|—|Detalle de abastecimiento|Referencia al detalle de insumos y cantidades solicitadas|Especifica los insumos requeridos, fundamentales para la planificación de la compra|
 
 ##  **ENTIDAD:** Propuesta de compra
 
@@ -332,12 +323,12 @@ Semántica: Plan de compra en base a la solicitud de abastecimiento.
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-|ID\_PROPUESTA\_COMPRA|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica cada propuesta de compra|Facilita la información de cada propuesta de compra para su revisión|
-|ID\_EMPLEADO|Relacional|Texto|Existente en Empleado, no nulo|—|Empleado|Identificador del operario que registra la propuesta de compra|Permite identificar quién realiza la planificación de compra de insumos|
+|COD\_PROPUESTA\_COMPRA|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica cada propuesta de compra|Facilita la información de cada propuesta de compra para su revisión|
+|COD\_EMPLEADO|Relacional|Texto|Existente en Empleado, no nulo|—|Empleado|Identificador del operario que registra la propuesta de compra|Permite identificar quién realiza la planificación de compra de insumos|
 |FECHA\_PROPUESTA\_COMPRA|Temporal|Fecha|Válido en calendario|—|—|Fecha en la que se registra la propuesta de compra|Determina el momento de planificación para control y seguimiento|
 |HORA\_PROPUESTA\_COMPRA|Temporal|Hora|Válida según zona horaria |—|—|Hora exacta en la que se genera la propuesta|Apoya en el orden temporal y trazabilidad del proceso de compras|
 |ESTADO\_PROPUESTA\_COMPRA|Estado|Texto|Pendiente, aprobado, rechazado|—|—|Indica si la propuesta está pendiente, aprobada o rechazada|Define el estado de avance de la planificación de compras|
-|ID\_PROVEEDOR|Relacional|Texto|Existente en Proveedor, no nulo|—|Proveedor|Código que indica a que proveedor pertenece la propuesta de compra|Facilita la información para saber a que proveedor pertenece la propuesta de compra|
+|COD\_PROVEEDOR|Relacional|Texto|Existente en Proveedor, no nulo|—|Proveedor|Código que indica a que proveedor pertenece la propuesta de compra|Facilita la información para saber a que proveedor pertenece la propuesta de compra|
 |FECHA\_ACUERDO\_ENTREGA|Temporal|Fecha|Válido en calendario|—|—|Fecha pactada con el proveedor para la entrega de los insumos|Determina el compromiso de entrega dentro de los términos negociados|
 |HORA\_ACUERDO\_ENTREGA|Temporal|Hora|Válida según zona horaria |—|—|Hora específica acordada para la entrega de los insumos|Detalla la puntualidad y planificación logística en el acuerdo con el proveedor|
 |DESCUENTO|Descriptivo|Numérico|0-100|%|—|Porcentaje o monto descontado por el proveedor sobre el total de la compra|Representa beneficios económicos negociados durante la planificación de la compra|
@@ -349,9 +340,9 @@ Semántica: Documento formal que autoriza la adquisición de insumos a un provee
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-|ID\_ORDEN\_COMPRA|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica cada orden de compra.|Facilita la información de cada orden de compra previamente aprobada para su envío,|
-|ID\_PROPUESTA\_COMPRA|Relacional|Texto|Existente en propuesta de compra, no nulo|—|Propuesta de compra|Identificador de la propuesta de compra aprobada que origina la orden|Establece la trazabilidad entre lo planificado y la orden formal de compra|
-|ID\_EMPLEADO|Relacional|Texto|Existente en Empleado, no nulo|—|Empleado|Identificador del jefe del área de compras que aprueba y genera la orden|Permite saber quién es responsable de formalizar la compra ante el área de finanzas|
+|COD\_ORDEN\_COMPRA|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica cada orden de compra.|Facilita la información de cada orden de compra previamente aprobada para su envío,|
+|COD\_PROPUESTA\_COMPRA|Relacional|Texto|Existente en propuesta de compra, no nulo|—|Propuesta de compra|Identificador de la propuesta de compra aprobada que origina la orden|Establece la trazabilidad entre lo planificado y la orden formal de compra|
+|COD\_EMPLEADO|Relacional|Texto|Existente en Empleado, no nulo|—|Empleado|Identificador del jefe del área de compras que aprueba y genera la orden|Permite saber quién es responsable de formalizar la compra ante el área de finanzas|
 |ESTADO\_ORDEN\_COMPRA|Estado|Texto|Sin enviar, pendiente, pagado, cancelado|—|—|Indica si la orden está pendiente, enviada, pagada o cancelada|Refleja el progreso administrativo y logístico de la orden en el ciclo de compras|
 
 ##  **ENTIDAD:** Insumo
@@ -360,7 +351,7 @@ Semántica: Bien empleado en la fabricación del producto.
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-|ID\_INSUMO|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica a cada insumo |Facilita la información de cada insumo y relacionarlo a solicitudes al almacén |
+|COD\_INSUMO|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica a cada insumo |Facilita la información de cada insumo y relacionarlo a solicitudes al almacén |
 |NOMBRE\_INSUMO|Descriptivo|Texto|Texto libre|—|—|Nombre del insumo|Aporta claridad al producto para su manejo en la comunicación entre los empleados|
 |TIPO\_INSUMO|Categórico|Texto|Materia prima, aditivo, material empaque|—|—|Tipo de insumo|Clasifica el insumo según su naturaleza. Determina su participación en los procesos de producción|
 |UNIDAD\_MEDIDA|Descriptivo|Texto|Kilogramo, gramo, unidad (adimensional)|—|—|Unidad en la que se mide el insumo|Garantiza la coherencia en el manejo cuantitativo de insumos|
@@ -371,9 +362,9 @@ Semántica: Transacción confirmada de adquisición de insumos.
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-|ID\_COMPRA|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica cada compra|Facilita la información de cada compra previamente pagada|
-|ID\_ORDEN\_COMPRA|Relacional|Texto|Existente en Orden de compra|—|Orden de compra|Identificador de la orden de compra a la que está asociada esta compra|Vincula la compra con el documento formal aprobado y enviado para su ejecución|
-|ID\_LOTE\_INSUMO|Relacional|Texto|Existente en Lote de insumo, no nulo|—|Lote de insumo|Identificador del lote de insumo físico recibido como parte de la compra|Permite rastrear qué lote específico fue entregado en cumplimiento de la orden|
+|COD\_COMPRA|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica cada compra|Facilita la información de cada compra previamente pagada|
+|COD\_ORDEN\_COMPRA|Relacional|Texto|Existente en Orden de compra|—|Orden de compra|Identificador de la orden de compra a la que está asociada esta compra|Vincula la compra con el documento formal aprobado y enviado para su ejecución|
+|COD\_LOTE\_INSUMO|Relacional|Texto|Existente en Lote de insumo, no nulo|—|Lote de insumo|Identificador del lote de insumo físico recibido como parte de la compra|Permite rastrear qué lote específico fue entregado en cumplimiento de la orden|
 |ESTADO\_REVISIÓN\_COMPRA|Estado|Texto|Sin revisión, en proceso, aceptado, rechazado|—|—|Resultado del análisis de calidad según estándares establecidos|Informa si el lote recibido cumple los requisitos técnicos y de calidad antes de ingresar al stock|
 
 ##  **ENTIDAD:** Seguimiento de compra
@@ -382,8 +373,8 @@ Semántica: Proceso de rastrear la ubicación y estado de un pedido desde su ini
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-|ID\_SEGUIMIENTO\_COMPRA|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica cada seguimiento de compra|Facilita la información de cada seguimiento de compra para recibirla|
-|ID\_COMPRA|Relacional|Texto|Existente en Compra, no nulo|—|Compra|Identificador de la compra a la que pertenece el seguimiento|Relaciona el seguimiento del insumo con la compra previamente registrada|
+|COD\_SEGUIMIENTO\_COMPRA|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica cada seguimiento de compra|Facilita la información de cada seguimiento de compra para recibirla|
+|COD\_COMPRA|Relacional|Texto|Existente en Compra, no nulo|—|Compra|Identificador de la compra a la que pertenece el seguimiento|Relaciona el seguimiento del insumo con la compra previamente registrada|
 |FECHA\_INGRESO|Temporal|Fecha|Válido en calendario|—|—|Día en que los lotes fueron recibidos físicamente en la empresa|Permite controlar la puntualidad y trazabilidad del proceso de seguimiento de insumos|
 |HORA\_INGRESO|Temporal|Hora|Válida según zona horaria |—|—|Hora exacta de llegada de los lotes a la empresa|Ayuda a verificar si el proveedor cumplió con los plazos de entrega pactados|
 |ESTADO\_SEGUIMIENTO\_COMPRA|Estado|Texto|Pendiente, a tiempo, con retraso, cancelado|—|—|Estado inicial del lote recibido antes de pasar al control de calidad|Informa si la entrega fue aceptada sin problemas o requiere atención especial antes del control de calidad|
@@ -394,25 +385,15 @@ Semántica: Proceso de queja al proveedor iniciado por el área de compras tras 
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-|ID\_RECLAMO|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica cada reclamo de lote de insumo rechazado|Facilita la información de cada reclamo reclamo de lote de insumo rechazado por el área de calidad|
-|ID\_INSPECCION\_LOTE\_INSUMO|Relacional|Texto|Existente en Inspección lote de insumo, no nulo|—|Inspección lote de insumo|Identificador de la inspección del lote de insumo rechazado|Permite rastrear el motivo del reclamo basándose en una evaluación previa del lote rechazado|
-|ID\_EMPLEADO|Relacional|Texto|Existente en Empleado, no nulo|—|Empleado|Identificador del empleado del área de compras que realiza el reclamo|Asocia el reclamo a un responsable del seguimiento y gestión del mismo|
+|COD\_RECLAMO|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica cada reclamo de lote de insumo rechazado|Facilita la información de cada reclamo reclamo de lote de insumo rechazado por el área de calidad|
+|COD\_INSPECCION\_LOTE\_INSUMO|Relacional|Texto|Existente en Inspección lote de insumo, no nulo|—|Inspección lote de insumo|Identificador de la inspección del lote de insumo rechazado|Permite rastrear el motivo del reclamo basándose en una evaluación previa del lote rechazado|
+|COD\_EMPLEADO|Relacional|Texto|Existente en Empleado, no nulo|—|Empleado|Identificador del empleado del área de compras que realiza el reclamo|Asocia el reclamo a un responsable del seguimiento y gestión del mismo|
 |ESTADO\_RECLAMO|Estado|Texto|Sin atender, pendiente, terminado|—|—|Indica si el reclamo está pendiente, en proceso o resuelto|Facilita el monitoreo del avance del reclamo y su resolución con el proveedor|
 |OBJETIVO\_RECLAMO|Categórico|Texto|Reposición, devolución|—|—|Motivo o solicitud del reclamo, como reposición de lote o devolución del dinero.|Define la acción que se espera del proveedor ante el lote rechazado|
-|ID\_LOTE\_INSUMO|Descriptivo|Texto|Existente en Lote de insumo, no nulo|—|Lote de insumo|Identificador del lote involucrado en el reclamo|Relaciona el reclamo con el insumo específico rechazado y su seguimiento|
+|COD\_LOTE\_INSUMO|Descriptivo|Texto|Existente en Lote de insumo, no nulo|—|Lote de insumo|Identificador del lote involucrado en el reclamo|Relaciona el reclamo con el insumo específico rechazado y su seguimiento|
 |MONTO\_DEVUELTO|Descriptivo|Numérico|>0|—|—|Cantidad de dinero devuelta por el proveedor en caso de no reponer el lote|Registra el impacto financiero de la resolución del reclamo|
 |FECHA\_ENTREGA|Temporal|Fecha|Válido en calendario|—|—|Fecha en que el proveedor entrega el nuevo lote o realiza la devolución acordada|Verifica el cumplimiento en el tiempo de la solución acordada|
 |HORA\_ENTREGA|Temporal|Hora|Válida según zona horaria |—|—|Hora exacta de la entrega del nuevo lote o de la devolución|Apoya en la trazabilidad y control de tiempos respecto a la respuesta del proveedor|
-
-##  **ENTIDAD:** ProveedorxInsumo
-
-Semántica: Registra la relación comercial entre un proveedor y un insumo que ofrece.
-
-|**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
-| :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-|ID\_PROVEEDOR|Identificador|Texto|Existente en Proveedor, no nulo|—|Proveedor|Código que identifica al proveedor que ofrece el insumo|Vincula al proveedor con el insumo que puede ofrecer, formando parte de la relación comercial|
-|ID\_INSUMO|Identificador|Texto|Existente en Insumo, no nulo|—|Insumo|Código que identifica al insumo ofrecido por el proveedor|Representa el producto específico ofrecido por el proveedor dentro de la relación comercial|
-|PRECIO\_REFERENCIAL|Descriptivo|Numérico|>0|—|—|Precio propuesto por el proveedor para el insumo ofrecido|Base de comparación de precios para decisiones de compra y negociación con los proveedores|
 
 ## **ENTIDAD:**  Lote Insumo
 
@@ -422,7 +403,7 @@ Semántica: El inventario de los lotes de insumos almacenados en el almacén.
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
 |COD\_ LOTE\_INSUMO|Identificador|Texto |Único, no nulo|—|—|Identificador único e irrepetible de un inventario relacionado a un insumo|Permite el control y seguimiento del flujo de los insumos como la entrada y salida del almacén.|
 |COD\_INSUMO |Identificador|Texto |Existente en Insumos|—|—|Identificador único del insumo|Relaciona un insumo a un inventario para realizar seguimiento del insumo en el almacén.|
-|NUMERO\_ LOTE|Descriptivo|Numérico|Valores enteros mayores a cero|----|---|Código del lote referido a un insumo|Permite llevar un seguimiento del lote que ingreso en la recepción con el inventario |
+|NUM\_ LOTE|Descriptivo|Numérico|Valores enteros mayores a cero|----|---|Código del lote referido a un insumo|Permite llevar un seguimiento del lote que ingreso en la recepción con el inventario |
 |COD\_RECEPCION|Identificador|Texto |Existente en RecepcionInsumos|—|—|Identificador único e irrepetible de una recepción|Facilitar el registro de entrada de un insumo del inventario relacionado|
 |CANTIDAD\_RECIBIDA|Descriptivo|Numérico|Valores enteros mayores a cero|—|—|Cantidad que el empleado recibió en la recepción|Facilita el seguimiento de las cantidades que llegaron al almacén |
 |CANTIDAD\_DISPONIBLE|Descriptivo|Numérico|Valores enteros mayores a cero|—|—|Cantidad disponible de un insumo de un lote relacionado|Permite el seguimiento del stock en el almacén.|
@@ -461,9 +442,9 @@ Semántica: Registro generado por el área de almacén para comunicar la necesid
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad**|**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
 |COD\_SOLICITUD\_INSUMOS|Identificador|Texto |Único, no nulo|—|—|Identificador único de cada solicitud de insumo|Permite rastrear cada solicitud para su seguimiento y trazabilidad|
-|ID\_DETALLE\_SOLICITUD|Identificador|Texto |Existente en DetalleSolicitud|—|—|Identificador único del detalle de la solicitud  |Determina a que detalle de solicitud está relacionado|
-|ID\_EMP´LEADO|Identificador|Texto |Existente en Empleado|—|—|Identificador único del empleado|Asigna la responsabilidad de la solicitud de insumos a un empleado específico|
-|NUMERO\_SOLICITUD|Descriptivo|Numérico|Valores enteros mayores a cero|—|---|Numero de la solicitud de insumos|Permite ser usado en documentación interna del área |
+|COD\_DETALLE\_SOLICITUD|Identificador|Texto |Existente en DetalleSolicitud|—|—|Identificador único del detalle de la solicitud  |Determina a que detalle de solicitud está relacionado|
+|COD\_EMP´LEADO|Identificador|Texto |Existente en Empleado|—|—|Identificador único del empleado|Asigna la responsabilidad de la solicitud de insumos a un empleado específico|
+|NUM\_SOLICITUD|Descriptivo|Numérico|Valores enteros mayores a cero|—|---|Numero de la solicitud de insumos|Permite ser usado en documentación interna del área |
 |FECHA\_SOLICITUD|Temporal|Fecha|Válido de calendario|—|—|Fecha de la solicitud de insumos |Permite conocer la antigüedad de la solicitud|
 |HORA\_SOLICITUD|Temporal|Hora|Válida según zona horaria|---|---|Hora de la solicitud de insumos |Permite realizer  el seguimiento de la slicitud en cuanto a tiempo |
 
@@ -484,7 +465,7 @@ Semántica: Documento que registra el ingreso de productos al almacén.
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad** |**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
 |COD\_ingreso|Identificador|Texto|Único, no nulo|—|—|Identificador único e irrepetible del Registro de ingreso de productos al almacén.|Permite el control y seguimiento de los productos que entran al almacen.|
-|CODIGO\_PRODUCTO|Identificador|Texto|Único, no nulo|—|—|Identificador del producto que se registrara su entrada |Relaciona la registro con un producto específico para su ingreso|
+|COD\_PRODUCTO|Identificador|Texto|Único, no nulo|—|—|Identificador del producto que se registrara su entrada |Relaciona la registro con un producto específico para su ingreso|
 |CANTIDAD|Descriptivo|Numérico|Valores enteros mayores a cero|Kilogramos|—|Número total de unidades que se ingresaran uno o más lotes para el almacén|Define el volumen de producto que ingresa.|
 |FECHA\_ingreso|Temporal|Fecha|Válido de calendario|—|—|Fecha donde se registro|Identifica la fecha de registro para su sequimiento|
 |NUM\_LOTE\_PRODUCTO|Identificador|Texto|Único, no nulo|—|—|Código único e irrepetible que identifica cada lote de producción|Permite la trazabilidad y control de cada lote de producto|
@@ -542,7 +523,7 @@ Semántica: Gestiona la preparación de productos con una orden de compra para s
 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad** |**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-|CODIGO\_pickin|Identificador|Texto|Único, no nulo|—|—|Identificador de la operación de picking |Relaciona la orden de compra con un embarque|
+|COD\_pickin|Identificador|Texto|Único, no nulo|—|—|Identificador de la operación de picking |Relaciona la orden de compra con un embarque|
 |CANTIDAD|Descriptivo|Numérico|Valores enteros mayores a cero|Kilogramos|—|Número total de unidades que se ingresaran uno o más lotes para el almacén|Define el volumen de producto que ingresa.|
 |Descripcion|Observacion|Texto|Único, no nulo|—|—|Observación que se da del proceso de salida| Comentario del proceso de salida dando una observacion|
 |FECHA\_ingreso|Temporal|Fecha|Válido de calendario|—|—|Fecha donde se hiso el picking | Identifica la fecha de registro para su seguimiento|
@@ -594,7 +575,7 @@ Semántica: Evento que compromete los recursos necesarios y especifica detalles 
 |**Atributo**|**Naturaleza (tipo de valor)**|**Formato**|**Valores válidos**|**Unidad** |**Derivada de**|**Semántica (descripción)**|**Ontología (rol en el negocio)**|
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
 |FECHA\_PROGRAMACION|Temporal|Fecha|Válido de calendario|—|—|Fecha en que se programó la Orden de Carga|Permite la trazabilidad al indicar cuándo fue programada la Orden de Carga|
-|CODIGO\_EMPLEADO|Descriptivo|Texto|No nulo|—|—|Documento nacional de identidad del conductor|Identificar al empleado responsable de la programación del despacho|
+|COD\_EMPLEADO|Descriptivo|Texto|No nulo|—|—|Documento nacional de identidad del conductor|Identificar al empleado responsable de la programación del despacho|
 |FECHA\_PROG\_SALIDA|Temporal|Fecha|Válido de calendario|—|—|Fecha planificada de salida del transporte|Definir agenda del transportista|
 |HORA\_PROG\_SALIDA|Temporal|Hora|Válida según zona horaria|—|—|Hora programada para iniciar el despacho|Sincronizar tiempos y logística con otros pedidos|
 

--- a/5/5.2/5.2.md
+++ b/5/5.2/5.2.md
@@ -483,16 +483,6 @@ Semántica: Documento que formaliza una queja o solicitud de devolución de insu
 |RPS|Reposición|
 |DVL|Devolución|
 
-## **ENTIDAD:** ProveedorxInsumo
-
-Semántica: Entidad intermedia que representa la relación muchos a muchos entre proveedores e insumos. Permite registrar qué proveedor ofrece qué insumo, incluyendo un precio referencial.
-
-|**Atributo**|**Tipo de Dato**|**Formato**|**Clave**|**Valores Válidos**|**Semántica**|
-| :-: | :-: | :-: | :-: | :-: | :-: |
-|ID\_PROVEEDOR|CHAR|XX9999|FK|NOT NULL, UNIQUE|Identificador único del proveedor|
-|ID\_INSUMO|CHAR|XX999|FK|NOT NULL|Identifica los insumos pertenecientes al proveedor|
-|PRECIO\_REFERENCIAL|FLOAT|99\.99||NOT NULL|Indica el precio de los insumos que ofrece el proveedor|
-
 ## **ENTIDAD:** Lote Insumo
 
 Semántica: El inventario de los lotes de insumos almacenados en el almacén.
@@ -588,8 +578,7 @@ Semántica: Evaluación del lote al momento de recepción por parte del área de
 |COMENTARIO|CHAR|X (50)||OPCIONAL|Observaciones del inspector respecto al resultado de la inspección.|Permite dejar constancia de hallazgos o decisiones tomadas.|
 |EVIDENCIA|CHAR|X (30)||OPCIONAL|Archivos (fotos, informes técnicos, etc.) que respalden el resultado de la inspección.|Soporte documental o visual del análisis realizado.|
 
-
-TAB19
+### TAB19
 
 |CÓDIGO|SEMÁNTICA|
 | :-: | :-: |
@@ -615,7 +604,7 @@ Semántica: Validación realizada por el área de calidad sobre cada proceso ind
 |COMENTARIO|CHAR|X (50)||OPCIONAL|Observaciones del inspector respecto al resultado de la inspección.|Permite dejar constancia de hallazgos o decisiones tomadas.|
 |EVIDENCIA|CHAR|X (30)||OPCIONAL|Archivos (fotos, informes técnicos, etc.) que respalden el resultado de la inspección.|Soporte documental o visual del análisis realizado.|
 
-TAB20
+### TAB20
 
 |CÓDIGO|SEMÁNTICA|
 | :-: | :-: |
@@ -653,8 +642,7 @@ Semántica: Acción concreta de recojo físico de productos como parte de una so
 |ES\_REEMPLAZO|BOOLEAN|Booleano||TRUE / FALSE|Indica si el picking ha sido generado como reposición por rechazo de una inspección.|Permite diferenciar si el picking corresponde al primer intento o a un reemplazo posterior.|
 |ESTADO\_PICKING|CHAR|XXX||TAB21|Estado actual del picking|Ayuda al seguimiento del flujo operativo|
 
-
-TAB21
+### TAB21
 
 |CÓDIGO|SEMÁNTICA|
 | :-: | :-: |
@@ -677,7 +665,6 @@ Semántica: Evaluación por parte de calidad a los empaques seleccionados antes 
 |COMENTARIO|CHAR|X (50)||OPCIONAL|Observaciones del inspector respecto al resultado de la inspección.|Permite dejar constancia de hallazgos o decisiones tomadas.|
 |EVIDENCIA|CHAR|X (30)||OPCIONAL|Archivos (fotos, informes técnicos, etc.) que respalden el resultado de la inspección.|Soporte documental o visual del análisis realizado.|
 
-
 ## **ENTIDAD:** Vehículo
 
 Semántica: Unidad de transporte en la que se trasladan los productos fuera de la planta de producción.
@@ -691,7 +678,7 @@ Semántica: Unidad de transporte en la que se trasladan los productos fuera de l
 |CAPACIDAD\_PESO|INT|999|||Capacidad de carga|Límite de productos a transportar|
 |CAPACIDAD\_EMPAQUES|INT|999|||Capacidad de carga en número de empaques|Límite de productos a transportar|
 
-TAB22
+### TAB22
 
 |CÓDIGO|SEMÁNTICA|
 | :-: | :-: |
@@ -699,13 +686,12 @@ TAB22
 |C|Camión|
 |M|Miniván|
 
-TAB23
+### TAB23
 
 |CÓDIGO|SEMÁNTICA|
 | :-: | :-: |
 |A|Activo|
 |I|Inactivo|
-
 
 ## **ENTIDAD:** Transportista
 
@@ -720,13 +706,11 @@ Semántica: Persona que se encarga de trasladar productos fuera de la planta de 
 |TIPO\_SERVICIO||X|TAB24||Tipo de servicio|Clasifica el servicio de transporte|
 |NUM\_LICENCIA||X99999999||NOT NULL, UNIQUE|Número de licencia de conducir válida|Cumplimiento legal|
 
-TAB24
+### TAB24
 |CÓDIGO|SEMÁNTICA|
 | :-: | :-: |
 |P|Propio de la empresa|
 |T|Tercerizado|
-
-
 
 ## **ENTIDAD:** Guía de Remisión
 Semántica: Documento que certifica la legalidad del traslado de bienes
@@ -741,7 +725,7 @@ Semántica: Documento que certifica la legalidad del traslado de bienes
 |ORIGEN\_DIRECCION|VARCHAR|X(150)||NOT NULL|Dirección de salida del transporte|Control de la ruta|
 |DESTINO\_DIRECCION|VARCHAR|X(150)||NOT NULL|Dirección de llegada del transporte|Control de la ruta|
 
-TAB25
+### TAB25
 
 |CÓDIGO|SEMÁNTICA|
 | :-: | :-: |
@@ -778,7 +762,7 @@ Semántica:** Documento que detalla la entrega y conformidad del cliente respect
 |HORA\_LLEGADA|TIME|HH:MM|||Hora en que se recibió el producto|Control y verificación del cumplimiento|
 |ESTADO|CHAR|X||TAB26|Estado del pedido al llegar|Notificar al encargado la creacion de guías de remisión|
 
-TAB26
+### TAB26
 |CÓDIGO|SEMÁNTICA|
 | :-: | :-: |
 |C|Entrega conforme|
@@ -798,7 +782,7 @@ Semántica: Documento que define los detalles y condiciones del transporte de pr
 |HORA\_SALIDA|TIME|HH:MM|||Hora en que salió el transporte|Control y verificación del cumplimiento|
 |ESTADO|CHAR|X||TAB|Estado de la orden de carga|Control y seguimiento del despacho|
 
-TA27
+### TAB27
 |CÓDIGO|SEMÁNTICA|
 | :-: | :-: |
 |C|Entrega conforme|
@@ -817,7 +801,7 @@ Semántica: Tabla intermedia que registra la información de los pedidos asociad
 |ID\_PROG\_DESP|CHAR|XX999999|FK|NOT NULL|Programación de despacho asociada|Asociar a una orden de carga|
 |MOTIVO\_DESPACHO|CHAR|X||TAB|Motivo por el cual se despacha ese pedido|Naturaleza del despacho|
 
-TA28
+### TAB28
 |CÓDIGO|SEMÁNTICA|
 | :-: | :-: |
 |V|Venta normal|


### PR DESCRIPTION
Se corrigieron ciertos errores encontrados en los diccionarios:

- Por parte del diccionario del modelo conceptual, algunos atributos no seguían el formato establecido, como también se reemplazaron los IDs a COD.
- Por parte del diccionario del modelo relacional, habían tablas que no tenían el formato establecido.
